### PR TITLE
fix(dracut-lib.sh): Don't change the provided UUID

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -594,10 +594,10 @@ label_uuid_to_dev() {
             echo "/dev/disk/by-partlabel/$(echo "${_dev#PARTLABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
             ;;
         UUID=*)
-            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}" | tr "[:upper:]" "[:lower:]")"
+            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}")"
             ;;
         PARTUUID=*)
-            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}" | tr "[:upper:]" "[:lower:]")"
+            echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}")"
             ;;
     esac
 }


### PR DESCRIPTION
This was introduced by 
 https://github.com/dracutdevs/dracut/commit/d3532978de04c78f53664dad7b37705a49a7ee54

This pull request changes...

## Changes
During boot dracut parses the provided UUID to lower case and thus starts an endless loop wating for the divese to appear. The divice is actually mapped correctly by the kernel (which doesn't tweak the UUID) but because we are waiting for a name with lower charachters the expeted device never appers which drops us at the emergency shell leaving the system unbootable.
This happens especially on nfts/fat filesystems because technically those don't have a UUID but a searial numbers which are used by the linux tools as UUID.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
https://github.com/dracutdevs/dracut/issues/1635
